### PR TITLE
Betterments to peer review db instructions

### DIFF
--- a/_content/osa-3/tuotantoon.md
+++ b/_content/osa-3/tuotantoon.md
@@ -2,6 +2,9 @@
 
 Sovelluksen laittaminen _tuotantoon_ tarkoittaa, että sovellus julkaistaan käyttäjille. Tällä kurssilla harjoittelemme tuotantoon laittamista [Fly.io](https://fly.io)-palvelun avulla. Fly.io tarjoaa ilmaiseksi palvelintilaa, jonne voi sijoittaa muun muassa Flaskilla toteutetun web-sovelluksen.
 
+<mark>HUOM! 3. periodissa sovelluksen ei tarvitse olla testattavissa tuotantopalvelimella. Riittää, että sen saa käynnistettyä paikallisesti.
+Lisätietoja <a href="/materiaali/aikataulu#huomio-flyiosta">täällä</a>.</mark>
+
 Käymme läpi seuraavaksi esimerkin, jossa siirrämme äsken luodun kävijäsovelluksen Fly.ioon. Jotta voit käyttää Fly.ioa, sinun täytyy luoda ensin tunnus palveluun. Tunnuksen luominen on ilmaista, mutta huomaa, että Fly.io tarjoaa myös maksullisia palveluja. Voit myös kirjautua Github-tunnuksillasi.
 
 Flyn ilmaisversiossa on tiettyjä rajoituksia erityisesti suorituskykyyn liittyen. Tämän kurssin puitteisiin ilmaisversion tarjoamat ominaisuudet kuitenkin riittävät hyvin. Voit lukea palvelun rajoituksista tarkemmin [täältä](https://fly.io/docs/about/pricing/) sekä ilmaisten Postgres-tietokantojen rajoituksista [täältä](https://fly.io/docs/postgres/#about-free-postgres-on-fly-io).

--- a/_pages/vertaisarviointi.md
+++ b/_pages/vertaisarviointi.md
@@ -33,3 +33,5 @@ $ psql -d <tietokannan-nimi> < schema.sql
 ```
 
 Määritä vielä tietokannan osoite projektille siten, että osoite päättyy luomasi tietokannan nimeen.
+Esimerkiksi, jos omalla sovelluksellasi osoite on muotoa `postgresql:///user` ja loit vertaisarviontia varten tietokannan nimeltä `testi`,
+tulisi uudeksi tietokannan osoitteeksi `postgresql:///testi`.


### PR DESCRIPTION
Added an example of a database url that can be used for peer reviewing.

Also added a note about fly.io deployoment being optional to part 3.